### PR TITLE
Allow to use custom database driver

### DIFF
--- a/src/Connection/Sql.php
+++ b/src/Connection/Sql.php
@@ -57,11 +57,32 @@ class Sql implements ConnectionInterface, PingableInterface
             'driver'   => $config->get('type'),
         );
 
+        if ($config->get('type') == 'other' && !empty($config->get('driverClass'))) {
+            unset($params['driver']);
+            $params['driverClass'] = $config->get('driverClass');
+        }
+        
+        if ($config->get('port') != '') {
+        	$params['port'] = $config->get('port');
+        }
+
         if ($config->get('type') == 'pdo_mysql') {
             $params['charset'] = 'utf8';
             $params['driverOptions'] = [
                 \PDO::ATTR_EMULATE_PREPARES => false,
             ];
+        }
+
+        parse_str($config->get('customOptions'), $customOptions);
+        $params = array_merge($params, $customOptions);
+
+        parse_str($config->get('driverOptions'), $driverOptions);
+        if (!empty($driverOptions)) {
+            if (!empty($params['driverOptions'])) {
+                $params['driverOptions'] = array_merge($params['driverOptions'], $driverOptions);
+            } else {
+                $params['driverOptions'] = $driverOptions;
+            }
         }
 
         return DriverManager::getConnection($params);
@@ -75,13 +96,18 @@ class Sql implements ConnectionInterface, PingableInterface
             'sqlsrv'      => 'Microsoft SQL Server',
             'oci8'        => 'Oracle Database',
             'sqlanywhere' => 'SAP Sybase SQL Anywhere',
+            'other'       => 'Custom driver class',
         );
 
         $builder->add($elementFactory->newSelect('type', 'Type', $types, 'The driver which is used to connect to the database'));
+        $builder->add($elementFactory->newInput('driverClass', 'Driver class', 'text', 'Custom driver class name'));
         $builder->add($elementFactory->newInput('host', 'Host', 'text', 'The IP or hostname of the database server'));
+        $builder->add($elementFactory->newInput('port', 'Port', 'number', 'The port used to connect to the database server'));
         $builder->add($elementFactory->newInput('username', 'Username', 'text', 'The name of the database user'));
         $builder->add($elementFactory->newInput('password', 'Password', 'password', 'The password of the database user'));
         $builder->add($elementFactory->newInput('database', 'Database', 'text', 'The name of the database which is used upon connection'));
+        $builder->add($elementFactory->newInput('customOptions', 'Custom options', 'text', 'Custom options for this connection, like charset etc. Formatted as URL arguments'));
+        $builder->add($elementFactory->newInput('driverOptions', 'Driver options', 'text', 'Additional options of this connection, specific to the driver. Formatted as URL arguments'));
     }
 
     public function ping($connection)


### PR DESCRIPTION
This commit adds the possibility to use custom database driver, as well as passing custom options for the driver.

As I deal mostly with some non-typical and/or legacy databases, the default drivers provided by DBAL itself are not very useful.
As passing the driver's class through URL is not possible, I've decided to modify Sql.php instead of SqlAdvanced.php.

The difference between customOptions and driverOptions is that some drivers look for specific parameters directly in the $params array. customOptions extend the $params while driverOptions extends $params['driverOptions'].

I am sucessfully using this modification to connect to Firebird 2.5.x databases using this driver -> https://github.com/rimas-kudelis/doctrine-firebird-driver/tree/f-pdo. 